### PR TITLE
Implemented a provider for CloudBees Feature Management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,6 @@ fib-algo=default
 
 # Split IO server-side API key
 SPLIT_KEY=
+
+# CloudBees App Key
+CLOUDBEES_APP_KEY=

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "scripts": {
     "no-op-demo": "nx serve api",
+    "cloudbees-demo": "nx run api:cloudbees-demo",
     "env-var-demo": "nx run api:env-var-demo",
     "split-demo": "nx run api:split-demo"
   },
@@ -33,12 +34,14 @@
     "@types/express": "4.17.13",
     "@types/jest": "27.0.2",
     "@types/node": "^16.11.7",
+    "@types/rox-node": "^5.0.1",
     "@typescript-eslint/eslint-plugin": "~5.10.0",
     "@typescript-eslint/parser": "~5.10.0",
     "eslint": "~8.7.0",
     "eslint-config-prettier": "8.1.0",
     "jest": "27.2.3",
     "prettier": "^2.5.1",
+    "rox-node": "^5.2.0",
     "ts-jest": "27.0.5",
     "typescript": "~4.5.2"
   }

--- a/packages/api/project.json
+++ b/packages/api/project.json
@@ -42,6 +42,15 @@
       }
     },
 
+    "cloudbees-demo": {
+      "executor": "@nrwl/node:node",
+      "options": {
+        "waitUntilTargets": ["js-cloudbees-provider:build", "openfeature-js:build"],
+        "buildTarget": "api:build",
+        "runtimeArgs": ["-r", "./scripts/tracing.js", "-r", "./scripts/cloudbees-demo.js"],
+        "inspect": true
+      }
+    },
     "split-demo": {
       "executor": "@nrwl/node:node",
       "options": {

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -12,7 +12,7 @@ const app = express();
 const oFeatClient = openfeature.getClient('api');
 
 app.get('/api', async (req, res) => {
-  const message = (await oFeatClient.isEnabled('new-welcome-message'))
+  const message = (await oFeatClient.getVariation('new-welcome-message')).boolValue
     ? 'Welcome to the next gen api!'
     : 'Welcome to the api!';
   res.send({ message });

--- a/packages/js-cloudbees-provider/.eslintrc.json
+++ b/packages/js-cloudbees-provider/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/js-cloudbees-provider/README.md
+++ b/packages/js-cloudbees-provider/README.md
@@ -1,0 +1,12 @@
+# js-cloudbees-provider
+
+This is the provider implementation for [CloudBees Feature Management](https://app.rollout.io).
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build js-cloudbees-provider` to build the library.
+
+## Running unit tests
+
+Run `nx test js-cloudbees-provider` to execute the unit tests via [Jest](https://jestjs.io).

--- a/packages/js-cloudbees-provider/jest.config.js
+++ b/packages/js-cloudbees-provider/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  displayName: 'js-cloudbees-adaptor',
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  transform: {
+    '^.+\\.[tj]s$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/packages/js-cloudbees-adaptor',
+};

--- a/packages/js-cloudbees-provider/package-lock.json
+++ b/packages/js-cloudbees-provider/package-lock.json
@@ -1,0 +1,84 @@
+{
+  "name": "@openfeature/js-cloudbees-provider",
+  "version": "0.0.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openfeature/js-cloudbees-provider",
+      "version": "0.0.1",
+      "dependencies": {
+        "@types/rox-node": "^5.0.1",
+        "rox-node": "^5.2.0"
+      }
+    },
+    "node_modules/@types/rox-node": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/rox-node/-/rox-node-5.0.1.tgz",
+      "integrity": "sha512-BbGqJnV56CTwiTWKkKTkmOoYEXMAR0mwpCEmS9coZpnY+AmNkTSj9/9gMKtRDGsMNkzTDHbjN0BJpeCygedGlg=="
+    },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rox-node": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/rox-node/-/rox-node-5.2.0.tgz",
+      "integrity": "sha512-Us8zThDZXRhgURhq5R2CYHUXUCGABEga1Y5fzSIxhY4jptGb6SxBFOsnOB53KUsW+AjxGf5Ni6wmKmUZ5oObFA==",
+      "dependencies": {
+        "axios": "^0.26.0"
+      }
+    }
+  },
+  "dependencies": {
+    "@types/rox-node": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/rox-node/-/rox-node-5.0.1.tgz",
+      "integrity": "sha512-BbGqJnV56CTwiTWKkKTkmOoYEXMAR0mwpCEmS9coZpnY+AmNkTSj9/9gMKtRDGsMNkzTDHbjN0BJpeCygedGlg=="
+    },
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+    },
+    "rox-node": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/rox-node/-/rox-node-5.2.0.tgz",
+      "integrity": "sha512-Us8zThDZXRhgURhq5R2CYHUXUCGABEga1Y5fzSIxhY4jptGb6SxBFOsnOB53KUsW+AjxGf5Ni6wmKmUZ5oObFA==",
+      "requires": {
+        "axios": "^0.26.0"
+      }
+    }
+  }
+}

--- a/packages/js-cloudbees-provider/package.json
+++ b/packages/js-cloudbees-provider/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@openfeature/js-cloudbees-provider",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "dependencies": {
+    "@types/rox-node": "^5.0.1",
+    "rox-node": "^5.2.0"
+  }
+}

--- a/packages/js-cloudbees-provider/project.json
+++ b/packages/js-cloudbees-provider/project.json
@@ -1,0 +1,32 @@
+{
+  "root": "packages/js-cloudbees-provider",
+  "sourceRoot": "packages/js-cloudbees-provider/src",
+  "targets": {
+    "build": {
+      "executor": "@nrwl/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/js-cloudbees-provider",
+        "main": "packages/js-cloudbees-provider/src/index.ts",
+        "tsConfig": "packages/js-cloudbees-provider/tsconfig.lib.json",
+        "assets": ["packages/js-cloudbees-provider/*.md"]
+      }
+    },
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["packages/js-cloudbees-provider/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/packages/js-cloudbees-provider"],
+      "options": {
+        "jestConfig": "packages/js-cloudbees-provider/jest.config.js",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/js-cloudbees-provider/src/index.ts
+++ b/packages/js-cloudbees-provider/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/js-cloudbees-provider';

--- a/packages/js-cloudbees-provider/src/lib/js-cloudbees-provider.ts
+++ b/packages/js-cloudbees-provider/src/lib/js-cloudbees-provider.ts
@@ -1,0 +1,47 @@
+import {
+  FeatureProvider,
+  FlagEvaluationRequest,
+  FlagEvaluationVariationResponse,
+} from '@openfeature/openfeature-js';
+
+import * as Rox from 'rox-node';
+
+export class CloudbeesProvider implements FeatureProvider {
+  name = 'cloudbees';
+
+  constructor(private readonly appKey: string) {
+    Rox.setup(appKey, {}).then(() => {
+      console.log(`CloudBees Provider initialised: appKey ${appKey}`)
+    });
+  }
+
+  async evaluateFlag(
+    request: FlagEvaluationRequest
+  ): Promise<FlagEvaluationVariationResponse> {
+    /**
+     * CloudBees Feature management  uses different methods to distinguish between different types of flag.
+     * See https://docs.cloudbees.com/docs/cloudbees-feature-management/latest/feature-flags/dynamic-api:
+     * * Boolean flag value: Rox.dynamicApi.isEnabled
+     * * String flag value:  Rox.dynamicApi.value
+     * * Number flag value:  Rox.dynamicApi.getNumber
+    **/
+
+    /**
+     * CloudBees Feature Management also defines a default value for a flag in code.
+     * This default value is returned by the SDK if the flag is not enabled ('targeting' is off)
+     * See https://docs.cloudbees.com/docs/cloudbees-feature-management/latest/feature-flags/flag-default-values
+    **/
+    // This assumes a boolean flag. Should we include the flag type in the request?
+    const value = Rox.dynamicApi.isEnabled(request.flagId, false, request.context)
+
+    console.log(`${this.name} flag '${request.flagId}' has a value of '${value}'`);
+
+    return {
+      enabled: true, // Cloudbees will return default values if the flag is disabled, so from a caller's perspective it is always enabled
+      // Callers should not care if a flag is enabled or not
+      boolValue: value,
+      // stringValue: value.toString(),
+      // numberValue: value,
+    }
+  }
+}

--- a/packages/js-cloudbees-provider/tsconfig.json
+++ b/packages/js-cloudbees-provider/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/js-cloudbees-provider/tsconfig.lib.json
+++ b/packages/js-cloudbees-provider/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": []
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["**/*.spec.ts", "**/*.test.ts"]
+}

--- a/packages/js-cloudbees-provider/tsconfig.spec.json
+++ b/packages/js-cloudbees-provider/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/packages/js-env-provider/src/lib/js-env-provider.ts
+++ b/packages/js-env-provider/src/lib/js-env-provider.ts
@@ -1,7 +1,7 @@
 import {
   FeatureProvider,
   FlagEvaluationRequest,
-  FlagEvaluationResponse,
+  FlagEvaluationVariationResponse,
 } from '@openfeature/openfeature-js';
 
 export class OpenFeatureEnvProvider implements FeatureProvider {
@@ -9,13 +9,14 @@ export class OpenFeatureEnvProvider implements FeatureProvider {
 
   async evaluateFlag(
     request: FlagEvaluationRequest
-  ): Promise<FlagEvaluationResponse> {
+  ): Promise<FlagEvaluationVariationResponse> {
     console.log(`${this.name}: evaluation flag`);
     const flagValue = process.env[request.flagId];
 
     console.log(`Flag '${request.flagId}' has a value of '${flagValue}'`);
     return {
-      enabled:
+      enabled: !!flagValue,
+      boolValue:
         typeof flagValue === 'string' && flagValue.toLowerCase() === 'true',
     };
   }

--- a/scripts/cloudbees-demo.js
+++ b/scripts/cloudbees-demo.js
@@ -8,4 +8,4 @@ const { CloudbeesProvider } = require("../dist/packages/js-cloudbees-provider/sr
  * OpenFeature object.
  */
 console.log('Registering the OpenFeature environment provider');
-openfeature.registerProvider(new CloudbeesProvider('618538bd7ebdeef023b5ff0d'));
+openfeature.registerProvider(new CloudbeesProvider(process.env.CLOUDBEES_APP_KEY));

--- a/scripts/cloudbees-demo.js
+++ b/scripts/cloudbees-demo.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const { openfeature } = require('../dist/packages/openfeature-js/src');
+const { CloudbeesProvider } = require("../dist/packages/js-cloudbees-provider/src");
+
+/**
+ * Registers the environment variable provider to the globally scoped
+ * OpenFeature object.
+ */
+console.log('Registering the OpenFeature environment provider');
+openfeature.registerProvider(new CloudbeesProvider('618538bd7ebdeef023b5ff0d'));

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,6 +17,7 @@
     "baseUrl": ".",
     "paths": {
       "@openfeature/fibonacci": ["packages/fibonacci/src/index.ts"],
+      "@openfeature/js-cloudbees-provider": ["packages/js-cloudbees-provider/src/index.ts"],
       "@openfeature/js-env-provider": ["packages/js-env-provider/src/index.ts"],
       "@openfeature/js-split-adaptor": [
         "packages/js-split-adaptor/src/index.ts"

--- a/workspace.json
+++ b/workspace.json
@@ -4,6 +4,7 @@
     "api": "packages/api",
     "fibonacci": "packages/fibonacci",
     "js-env-provider": "packages/js-env-provider",
+    "js-cloudbees-provider": "packages/js-cloudbees-provider",
     "js-split-adaptor": "packages/js-split-adaptor",
     "openfeature-js": "packages/openfeature-js"
   }


### PR DESCRIPTION
![screen-recording](https://user-images.githubusercontent.com/1652511/159449002-c4b34d64-666c-4494-9675-0e3808b62936.gif)

This raises a few questions about the use/design of the API.

CloudBees uses flag names instead of IDs when evaluating flags. So the `FlagEvaluationRequest.flagId` parameter isn't quite appropriate here. It's simple to just infer that the ID gets translated to a name, but maybe it's worth renaming `FlagEvaluationRequest.flagId` to just ``FlagEvaluationRequest.flag`? Or if more providers use a 'name' rather than an ID just use ``FlagEvaluationRequest.flagName`.

CloudBees flags are typed (boolean/string/number). Because CloudBees flags are generated by the SDK when it runs (you don't have to pre-create the flag in our platform). When evaluating the flag, you need to use the correct method for the type: `isEnabled` (boolean flag); `value` (string flag), `getNumber` (number flag).
It may be worth passing the type into the flag as part of `FlagEvaulationRequest` in the same

CloudBees flags also define a default value (in code). Flags _always_ exist in CloudBees Feature Management (if the flag doesn't exist when you evaluate it in code, it will automatically create it in the platform for you - this is part of our design). Therefore there is no concept of a flag "not existing" or returning `null`. If the flag's targeting is turned off (disabled - not the same as setting a boolean flag to return false) then the default value will be used. I think this is a good pattern to use for flags in general. In user-land, the code calling the library should never care about whether a flag is enabled/disabled or not (this is a control-plane issue). 
