### PR TITLE
Add evaluation detail methods, updated providers, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To see this in action, we'll run the API app found
 registering a provider. Let's run the app and see what happens.
 
 1. Run `npm run no-op-demo`
-1. Open http://localhost:3333/api in your browser
+2. Open http://localhost:3333/api in your browser
 
 That's it! You should see **Welcome to the api!**. Unfortunately, that's all you
 can do without registering a provider. Thankfully, as we'll see in the next
@@ -99,8 +99,8 @@ provider **could** be implemented.
 Follow these steps to run the demo:
 
 1. copy `.env.example` to `.env`
-1. Run `npm run env-var-demo`
-1. Open http://localhost:3333/api in your browser
+2. Run `npm run env-var-demo`
+3. Open http://localhost:3333/api in your browser
 
 You should see **Welcome to the api!** just as before. Now, change the value of
 `new-welcome-message` to true and restart the app. It should show **Welcome
@@ -118,35 +118,65 @@ possible.
 Follow these steps to run the demo:
 
 1. Copy `.env.example` to `.env`
-1. Add a Split.io [service-side API
+2. Add a Split.io [service-side API
    key](https://help.split.io/hc/en-us/articles/360019916211-API-keys) to the
    `SPLIT_KEY` in the `.env` file.
-1. Create a new split called `new-welcome-message` with the default treatments
-1. Create a new split called `fib-algo` with the treatment values: `recursive`,
+3. Create a new split called `new-welcome-message` with the default treatments
+4. Create a new split called `fib-algo` with the treatment values: `recursive`,
    `memo`, `loop`, `binet`, and `default`.
-1. Run `npm run split-demo`
+5. Create a new split called `hex-color` with the treatment values: `CC0000`,
+   `00CC00`, `0000CC`, `chartreuse`.
+6. Run `npm run split-demo` and visit http://localhost:3333/api, http://localhost:3333/hello, or http://localhost:3333/fibonacci?num=40
 
-You can now remotely configure the welcome message and the algorithm used in
-the [Fibonacci
-library](./packages/fibonacci/src/lib/fibonacci.ts). The Fibonacci example is
-particularly interesting because registers a library-specific client. This would
-allow maintainers to include feature flagging in their libraries that could be
-remotely configured if desired. Also, if no provider is registered, the library
-will no-op and simply use the default algorithm.
+### CloudBees FM Provider Demo
 
-Experiment with different Fibonacci algorithms and hitting the API with these
-values:
+A CloudCees Feature Management provider demo.
 
-- http://localhost:3333/fibonacci?num=10
-- http://localhost:3333/fibonacci?num=20
-- http://localhost:3333/fibonacci?num=30
-- http://localhost:3333/fibonacci?num=40
-- http://localhost:3333/fibonacci?num=50
+Follow these steps to run the demo:
+
+1. Copy `.env.example` to `.env`
+2. Add a CloudBees app key to the `.env` file.
+3. Create a new boolean flag called `new-welcome-message`.
+4. Create a new flag called `fib-algo` with the values: `recursive`,
+   `memo`, `loop`, `binet`, and `default`.
+5. Create a new flag called `hex-color` with the values: `CC0000`,
+   `00CC00`, `0000CC`, `chartreuse`.
+6. Run `npm run cloudbees-demo` and visit http://localhost:3333/api, http://localhost:3333/hello, or http://localhost:3333/fibonacci?num=40
+
+### LaunchDarkly Provider Demo
+
+A LaunchDarkly provider demo.
+
+Follow these steps to run the demo:
+
+1. Copy `.env.example` to `.env`
+2. Add a LaunchDarkly SDK key to the `.env` file.
+3. Create a new boolean flag called `new-welcome-message`.
+4. Create a new feature flag called `fib-algo` with the values: `recursive`,
+   `memo`, `loop`, `binet`, and `default`.
+5. Create a new feature flag called `hex-color` with the values: `CC0000`,
+   `00CC00`, `0000CC`, `chartreuse`.
+6. Run `npm run launchdarkly-demo` and visit http://localhost:3333/api, http://localhost:3333/hello, or http://localhost:3333/fibonacci?num=40
+
+### Flagsmith (v1/v2) Provider Demo
+
+A Flagsmith provider demo.
+
+Follow these steps to run the demo:
+
+1. Copy `.env.example` to `.env`
+2. Add a Flagsmith Environment ID (v1) or a Environment key (v2) to the `.env` file.
+3. Create a new boolean feature called `new-welcome-message`.
+4. Create a new feature called `fib-algo` with the values: `recursive`,
+   `memo`, `loop`, `binet`, and `default`.
+5. Create a new feature called `hex-color` with the values: `CC0000`,
+   `00CC00`, `0000CC`, `chartreuse`.
+6. Run `npm run flagsmith-v1-demo` or `npm run flagsmith-v2-demo` and visit http://localhost:3333/api, http://localhost:3333/hello, or http://localhost:3333/fibonacci?num=40
+
+## OpenTelemetry Support
 
 Now, wouldn't it be nice if you could visually see the impact an algorithm had
 on a request? That's where OpenTelemetry support comes in.
-
-## OpenTelemetry Support
 
 Supporting OpenTelemetry natively in OpenFeature provides a number of
 advantages. The most obvious benefit is distributed traces would contain
@@ -162,11 +192,31 @@ overhead if you don't.
 ### OpenTelemetry Demo
 
 1. Start Zipkin in Docker: `docker run --rm -d -p 9411:9411 --name zipkin openzipkin/zipkin`
-1. Open http://localhost:9411/ in your browser
-1. Start one of the demos above or run `npm run no-op-demo`
-1. Open Zipkin and search for a trace
+2. Open http://localhost:9411/ in your browser
+3. Start one of the demos above or run `npm run no-op-demo`
+4. Open Zipkin and search for a trace
 
 ![Zipkin](./assets//images/zipkin-fibonacci.png)
+
+Experiment with different Fibonacci algorithms and hitting the API with these
+values:
+
+- http://localhost:3333/fibonacci?num=10
+- http://localhost:3333/fibonacci?num=20
+- http://localhost:3333/fibonacci?num=30
+- http://localhost:3333/fibonacci?num=40
+- http://localhost:3333/fibonacci?num=50
+
+### Validation Hook Demo
+
+"After" hooks can be used validate and intercept flag values. This is particularly useful
+if non-technical personnel have access to make changes to the feature flag values. Validators can
+ensure that only logical valid values for flags propagate through code.
+
+1. Start a provider demo (ie: `npm run env-var-demo`)
+2. Open http://localhost:3333/hello in your browser
+3. Change the value to any valid CSS hex value (ie: `AABB00`) and observe that value is used in the returned markup
+4. Change the value to any invalid CSS hex value (ie: `chartreuse`) and observe that value falls back to `000000`
 
 ### Baggage
 
@@ -209,7 +259,6 @@ header.
 
 ## Open Questions
 
-- How should a provider that requires an async start-up be handled?
 - What should happen if multiple providers are registered?
 - Could something similar to an OpenAPI be used to describe feature flags in code?
 - What OpenTelemetry semantic naming prefix should be used?

--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ Available demos:
 - [No-op](#no-op-demo)
 - [Environment Variable Provider](#environment-variable-provider-demo)
 - [Split Provider](#split-provider-demo)
+- [CloudBees Feature Management Provider](#cloudbees-fm-provider-demo)
+- [LaunchDarkly Provider Demo](#launchdarkly-provider-demo)
+- [Flagsmith Provider Demo](#flagsmith-provider-demo)
 - [OpenTelemetry and Zipkin](#opentelemetry-demo)
+- [Validation Hook Demo](#validation-hook-demo)
 
 ## Create a new provider
 
@@ -158,9 +162,9 @@ Follow these steps to run the demo:
    `00CC00`, `0000CC`, `chartreuse`.
 6. Run `npm run launchdarkly-demo` and visit http://localhost:3333/api, http://localhost:3333/hello, or http://localhost:3333/fibonacci?num=40
 
-### Flagsmith (v1/v2) Provider Demo
+### Flagsmith Provider Demo
 
-A Flagsmith provider demo.
+A Flagsmith provider demo (supports v1 and v2).
 
 Follow these steps to run the demo:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4615,9 +4615,9 @@
       }
     },
     "flagsmithv2": {
-      "version": "npm:flagsmith-nodejs@2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/flagsmith-nodejs/-/flagsmith-nodejs-2.0.0-beta.1.tgz",
-      "integrity": "sha512-PZwLJJFvsLat+L2ovDNmJFbvSYs+HVKM0Ve6AkzTd6lqrhSTeqe2ZqWnjd7wvylx/fG6gv58sUMnV9gx07HNLg==",
+      "version": "npm:flagsmith-nodejs@2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/flagsmith-nodejs/-/flagsmith-nodejs-2.0.0-beta.2.tgz",
+      "integrity": "sha512-+G7IgK25R5JdrugaNi2YppfWeDoZV0a3mOt6xQN+FUAfLOr8bxULD5Oa1C2rL1Pl1eTCkTay/WK1Xr5VNSG05w==",
       "requires": {
         "big-integer": "^1.6.51",
         "md5": "^2.3.0",

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -41,7 +41,7 @@ app.get('/hello', async (req, res) => {
     {
       hooks: [
         {
-          name: '',
+          name: 'validate-hex',
           after: (
             hookContext,
             evaluationDetails: FlagEvaluationDetails<string>

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -3,7 +3,10 @@
  * This is only a minimal backend to get started.
  */
 import * as express from 'express';
-import { openfeature } from '@openfeature/openfeature-js';
+import {
+  FlagEvaluationDetails,
+  openfeature,
+} from '@openfeature/openfeature-js';
 import { fibonacci } from '@openfeature/fibonacci';
 import { query, validationResult } from 'express-validator';
 import {
@@ -38,14 +41,18 @@ app.get('/hello', async (req, res) => {
     {
       hooks: [
         {
-          after: (hookContext, flagValue: string) => {
+          name: '',
+          after: (
+            hookContext,
+            evaluationDetails: FlagEvaluationDetails<string>
+          ) => {
             // validate the hex value.
             const hexPattern = /[0-9A-Fa-f]{6}/g;
-            if (hexPattern.test(flagValue)) {
-              return flagValue;
+            if (hexPattern.test(evaluationDetails.value)) {
+              return evaluationDetails.value;
             } else {
               console.warn(
-                `Got invalid flag value '${flagValue}' for ${hookContext.flagId}, returning ${hookContext.defaultValue}`
+                `Got invalid flag value '${evaluationDetails.value}' for ${hookContext.flagKey}, returning ${hookContext.defaultValue}`
               );
               return hookContext.defaultValue;
             }

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -4,6 +4,7 @@
  */
 import * as express from 'express';
 import {
+  Context,
   FlagEvaluationDetails,
   openfeature,
 } from '@openfeature/openfeature-js';
@@ -16,8 +17,8 @@ import {
 } from '@openfeature/extra';
 import { buildHelloMarkup } from './hello-markup';
 import { InstallTemplateData } from './types';
-import { buildInstallMarkup } from './install-markup';
 import { InstallTemplate } from './install-template';
+import { buildInstallMarkup } from './install-markup';
 
 const app = express();
 const appName = 'api';
@@ -89,7 +90,8 @@ app.get('/install', async (req, res) => {
   ).replace(/"/g, '');
 
   // add to the attributes
-  const attributes = {
+  const attributes: Context = {
+    userId: 'anonymous',
     platform,
   };
 

--- a/packages/js-cloudbees-provider/src/lib/js-cloudbees-provider.ts
+++ b/packages/js-cloudbees-provider/src/lib/js-cloudbees-provider.ts
@@ -1,7 +1,5 @@
 import {
-  ContextTransformer,
   FeatureProvider,
-  noopContextTransformer,
   parseValidJsonObject,
   ProviderEvaluation,
   ProviderOptions,
@@ -15,12 +13,9 @@ export interface CloudbeesProviderOptions extends ProviderOptions {
 
 export class CloudbeesProvider implements FeatureProvider {
   name = 'cloudbees';
-  readonly contextTransformer: ContextTransformer<unknown>;
   private initialized: Promise<void>;
 
   constructor(options: CloudbeesProviderOptions) {
-    this.contextTransformer =
-      options.contextTransformer || noopContextTransformer;
     // we don't expose any init events at the moment (we might later) so for now, lets create a private
     // promise to await into before we evaluate any flags.
     this.initialized = new Promise((resolve) => {

--- a/packages/js-env-provider/src/lib/js-env-provider.ts
+++ b/packages/js-env-provider/src/lib/js-env-provider.ts
@@ -1,92 +1,67 @@
 import {
-  Context,
   FeatureProvider,
-  FlagEvaluationOptions,
-  FlagTypeError,
-  FlagValueParseError,
+  FlagNotFoundError,
   noopContextTransformer,
   parseValidBoolean,
+  parseValidJsonObject,
   parseValidNumber,
+  ProviderEvaluation,
+  Reason,
 } from '@openfeature/openfeature-js';
 import { constantCase } from 'change-case';
 
 export class OpenFeatureEnvProvider implements FeatureProvider {
+  isEnabledEvaluation(flagKey: string): Promise<ProviderEvaluation<boolean>> {
+    const details = this.evaluateEnvironmentVariable(flagKey);
+    return Promise.resolve({
+      ...details,
+      value: parseValidBoolean(details.value),
+    });
+  }
+
+  getBooleanEvaluation(flagKey: string): Promise<ProviderEvaluation<boolean>> {
+    const details = this.evaluateEnvironmentVariable(flagKey);
+    return Promise.resolve({
+      ...details,
+      value: parseValidBoolean(details.value),
+    });
+  }
+  async getStringEvaluation(
+    flagKey: string
+  ): Promise<ProviderEvaluation<string>> {
+    return Promise.resolve(this.evaluateEnvironmentVariable(flagKey));
+  }
+
+  getNumberEvaluation(flagKey: string): Promise<ProviderEvaluation<number>> {
+    const details = this.evaluateEnvironmentVariable(flagKey);
+    return Promise.resolve({
+      ...details,
+      value: parseValidNumber(details.value),
+    });
+  }
+
+  getObjectEvaluation<U extends object>(
+    flagKey: string
+  ): Promise<ProviderEvaluation<U>> {
+    const details = this.evaluateEnvironmentVariable(flagKey);
+    return Promise.resolve({
+      ...details,
+      value: parseValidJsonObject(details.value),
+    });
+  }
   name = ' environment variable';
   readonly contextTransformer = noopContextTransformer;
 
-  isEnabled(
-    flagId: string,
-    defaultValue: boolean,
-    context: Context,
-    options?: FlagEvaluationOptions
-  ): Promise<boolean> {
-    return this.getBooleanValue(flagId, defaultValue, context, options);
-  }
-
-  getBooleanValue(
-    flagId: string,
-    _defaultValue: boolean,
-    _context: Context,
-    _options?: FlagEvaluationOptions
-  ): Promise<boolean> {
-    const stringValue = this.getVarValue(flagId);
-    if (stringValue) {
-      return Promise.resolve(parseValidBoolean(stringValue));
-    } else {
-      throw new FlagTypeError(`Error resolving ${flagId} from environment`);
-    }
-  }
-
-  getStringValue(
-    flagId: string,
-    _defaultValue: string,
-    _context: Context,
-    _options?: FlagEvaluationOptions
-  ): Promise<string> {
-    const stringValue = this.getVarValue(flagId);
-    if (stringValue) {
-      return Promise.resolve(stringValue);
-    } else {
-      throw new FlagTypeError(`Error resolving ${flagId} from environment`);
-    }
-  }
-
-  getNumberValue(
-    flagId: string,
-    _defaultValue: number,
-    _context: Context,
-    _options?: FlagEvaluationOptions
-  ): Promise<number> {
-    const stringValue = this.getVarValue(flagId);
-    if (stringValue) {
-      return Promise.resolve(parseValidNumber(stringValue));
-    } else {
-      throw new FlagTypeError(`Error resolving ${flagId} from environment`);
-    }
-  }
-
-  getObjectValue<T extends object>(
-    flagId: string,
-    _defaultValue: T,
-    _context: Context,
-    _options?: FlagEvaluationOptions
-  ): Promise<T> {
-    const stringValue = this.getVarValue(flagId);
-    if (stringValue) {
-      try {
-        const parsed = JSON.parse(stringValue);
-        return Promise.resolve(parsed);
-      } catch (err) {
-        throw new FlagValueParseError(`Error parsing ${flagId}`);
-      }
-    } else {
-      throw new FlagTypeError(`Error resolving ${flagId} from environment`);
-    }
-  }
-
-  getVarValue(key: string): string | undefined {
+  evaluateEnvironmentVariable(key: string): ProviderEvaluation<string> {
     // convert key to ENV_VAR style casing
     const envVarCaseKey = constantCase(key);
-    return process.env[envVarCaseKey];
+    const value = process.env[envVarCaseKey];
+    if (!value) {
+      throw new FlagNotFoundError();
+    }
+    return {
+      value: value,
+      reason: Reason.DEFAULT,
+    };
   }
 }

--- a/packages/js-env-provider/src/lib/js-env-provider.ts
+++ b/packages/js-env-provider/src/lib/js-env-provider.ts
@@ -1,7 +1,6 @@
 import {
   FeatureProvider,
   FlagNotFoundError,
-  noopContextTransformer,
   parseValidBoolean,
   parseValidJsonObject,
   parseValidNumber,
@@ -50,7 +49,6 @@ export class OpenFeatureEnvProvider implements FeatureProvider {
     });
   }
   name = ' environment variable';
-  readonly contextTransformer = noopContextTransformer;
 
   evaluateEnvironmentVariable(key: string): ProviderEvaluation<string> {
     // convert key to ENV_VAR style casing

--- a/packages/js-flagsmith-v2-provider/src/lib/flagsmith-v2.ts
+++ b/packages/js-flagsmith-v2-provider/src/lib/flagsmith-v2.ts
@@ -9,7 +9,7 @@ import {
   Reason,
   TypeMismatchError,
 } from '@openfeature/openfeature-js';
-import Flagsmith from 'flagsmithv2';
+import Flagsmith from 'flagsmithv2/build/sdk';
 
 type Identity = {
   identifier?: string;

--- a/packages/js-split-provider/src/lib/js-split-provider.ts
+++ b/packages/js-split-provider/src/lib/js-split-provider.ts
@@ -2,15 +2,22 @@ import {
   Context,
   ContextTransformer,
   FeatureProvider,
-  FlagEvaluationOptions,
-  FlagTypeError,
+  noopContextTransformer,
   parseValidJsonObject,
   parseValidNumber,
-  ProviderOptions
+  ProviderEvaluation,
+  ProviderOptions,
+  Reason,
+  TypeMismatchError,
 } from '@openfeature/openfeature-js';
-import type { IClient, Attributes } from '@splitsoftware/splitio/types/splitio';
-import { noopContextTransformer } from '@openfeature/openfeature-js';
+import type { Attributes, IClient } from '@splitsoftware/splitio/types/splitio';
 
+/**
+ * This simple provider implementation relies on storing all data as strings in the treatment value.
+ *
+ * It may be more idiomatic to only rely on that for the "isEnabled" calls,
+ * and for all values store the data in teh associated "split config" JSON.
+ */
 export interface SplitProviderOptions extends ProviderOptions {
   splitClient: IClient;
 }
@@ -18,17 +25,17 @@ export interface SplitProviderOptions extends ProviderOptions {
 /**
  * Transform the context into an object useful for the Split API, an key string with arbitrary Split "Attributes".
  */
- const DEFAULT_CONTEXT_TRANSFORMER = (context: Context): Consumer => {
+const DEFAULT_CONTEXT_TRANSFORMER = (context: Context): Consumer => {
   const { userId, ...attributes } = context;
   return {
     key: userId || 'anonymous',
-    attributes
+    attributes,
   };
 };
 
 type Consumer = {
   key: string;
-  attributes: Attributes
+  attributes: Attributes;
 };
 
 export class OpenFeatureSplitProvider implements FeatureProvider<Consumer> {
@@ -36,11 +43,12 @@ export class OpenFeatureSplitProvider implements FeatureProvider<Consumer> {
   readonly contextTransformer: ContextTransformer<Consumer>;
   private initialized: Promise<void>;
   private client: IClient;
-  
+
   constructor(options: SplitProviderOptions) {
     this.client = options.splitClient;
-    // f contextTransformer to map context to split "Attributes".
-    this.contextTransformer = DEFAULT_CONTEXT_TRANSFORMER || noopContextTransformer;
+    // contextTransformer to map context to split "Attributes".
+    this.contextTransformer =
+      DEFAULT_CONTEXT_TRANSFORMER || noopContextTransformer;
     // we don't expose any init events at the moment (we might later) so for now, lets create a private
     // promise to await into before we evaluate any flags.
     this.initialized = new Promise((resolve) => {
@@ -51,95 +59,88 @@ export class OpenFeatureSplitProvider implements FeatureProvider<Consumer> {
     });
   }
 
-  
-
-  async isEnabled(
-    flagId: string,
+  isEnabledEvaluation(
+    flagKey: string,
     defaultValue: boolean,
-    keyWithAttributes: Consumer,
-    options?: FlagEvaluationOptions
-  ): Promise<boolean> {
-    return this.getBooleanValue(flagId, defaultValue, keyWithAttributes, options);
+    consumer: Consumer
+  ): Promise<ProviderEvaluation<boolean>> {
+    return this.getBooleanEvaluation(flagKey, defaultValue, consumer);
   }
 
-  /**
-   * Split doesn't directly handle booleans as treatment values.
-   * It will be up to the provider author and it's users to come up with conventions for converting strings to booleans.
-   */
-  async getBooleanValue(
-    flagId: string,
-    defaultValue: boolean,
-    keyWithAttributes: Consumer,
-    options?: FlagEvaluationOptions
-  ): Promise<boolean> {
-    await this.initialized;
-    // simply casting Context to Attributes is likely a bad idea.
-    const stringValue = this.client.getTreatment(
-      keyWithAttributes.key,
-      flagId,
-      keyWithAttributes.attributes
-    );
-    const asUnknown = stringValue as unknown;
+  async getBooleanEvaluation(
+    flagKey: string,
+    _defaultValue: boolean,
+    consumer: Consumer
+  ): Promise<ProviderEvaluation<boolean>> {
+    const details = await this.evaluateTreatment(flagKey, consumer);
 
-    switch (asUnknown) {
+    let value: boolean;
+    switch (details.value as unknown) {
       case 'on':
-        return true;
+        value = true;
+        break;
       case 'off':
-        return false;
+        value = false;
+        break;
       case 'true':
-        return true;
+        value = true;
+        break;
       case 'false':
-        return false;
+        value = false;
+        break;
       case true:
-        return true;
+        value = true;
+        break;
       case false:
-        return false;
+        value = false;
+        break;
       default:
-        throw new FlagTypeError(`Invalid boolean value for ${asUnknown}`);
+        throw new TypeMismatchError(
+          `Invalid boolean value for ${details.value}`
+        );
     }
+    return { ...details, value };
   }
 
-  async getStringValue(
-    flagId: string,
-    defaultValue: string,
-    keyWithAttributes: Consumer,
-    options?: FlagEvaluationOptions
-  ): Promise<string> {
-    await this.initialized;
-    return this.client.getTreatment(
-      keyWithAttributes.key,
-      flagId,
-      keyWithAttributes.attributes
-    );
+  async getStringEvaluation(
+    flagKey: string,
+    _defaultValue: string,
+    consumer: Consumer
+  ): Promise<ProviderEvaluation<string>> {
+    return this.evaluateTreatment(flagKey, consumer);
   }
 
-  async getNumberValue(
-    flagId: string,
-    defaultValue: number,
-    keyWithAttributes: Consumer,
-    options?: FlagEvaluationOptions
-  ): Promise<number> {
-    await this.initialized;
-    const value = this.client.getTreatment(
-      keyWithAttributes.key,
-      flagId,
-      keyWithAttributes.attributes
-    );
-    return parseValidNumber(value);
+  async getNumberEvaluation(
+    flagKey: string,
+    _defaultValue: number,
+    consumer: Consumer
+  ): Promise<ProviderEvaluation<number>> {
+    const details = await this.evaluateTreatment(flagKey, consumer);
+    return { ...details, value: parseValidNumber(details.value) };
   }
 
-  async getObjectValue<T extends object>(
-    flagId: string,
-    defaultValue: T,
-    keyWithAttributes: Consumer,
-    options?: FlagEvaluationOptions
-  ): Promise<T> {
+  async getObjectEvaluation<U extends object>(
+    flagKey: string,
+    _defaultValue: U,
+    consumer: Consumer
+  ): Promise<ProviderEvaluation<U>> {
+    const details = await this.evaluateTreatment(flagKey, consumer);
+    return { ...details, value: parseValidJsonObject(details.value) };
+  }
+
+  private async evaluateTreatment(
+    flagKey: string,
+    consumer: Consumer
+  ): Promise<ProviderEvaluation<string>> {
     await this.initialized;
     const value = this.client.getTreatment(
-      keyWithAttributes.key,
-      flagId,
-      keyWithAttributes.attributes
+      consumer.key,
+      flagKey,
+      consumer.attributes
     );
-    return parseValidJsonObject(value);
+    return {
+      value,
+      reason: Reason.UNKNOWN,
+    };
   }
 }

--- a/packages/js-split-provider/src/lib/js-split-provider.ts
+++ b/packages/js-split-provider/src/lib/js-split-provider.ts
@@ -2,7 +2,6 @@ import {
   Context,
   ContextTransformer,
   FeatureProvider,
-  noopContextTransformer,
   parseValidJsonObject,
   parseValidNumber,
   ProviderEvaluation,
@@ -18,7 +17,7 @@ import type { Attributes, IClient } from '@splitsoftware/splitio/types/splitio';
  * It may be more idiomatic to only rely on that for the "isEnabled" calls,
  * and for all values store the data in teh associated "split config" JSON.
  */
-export interface SplitProviderOptions extends ProviderOptions {
+export interface SplitProviderOptions extends ProviderOptions<Consumer> {
   splitClient: IClient;
 }
 
@@ -48,7 +47,7 @@ export class OpenFeatureSplitProvider implements FeatureProvider<Consumer> {
     this.client = options.splitClient;
     // contextTransformer to map context to split "Attributes".
     this.contextTransformer =
-      DEFAULT_CONTEXT_TRANSFORMER || noopContextTransformer;
+      options.contextTransformer || DEFAULT_CONTEXT_TRANSFORMER;
     // we don't expose any init events at the moment (we might later) so for now, lets create a private
     // promise to await into before we evaluate any flags.
     this.initialized = new Promise((resolve) => {

--- a/packages/openfeature-extra/src/lib/hooks/class-validator-hook.ts
+++ b/packages/openfeature-extra/src/lib/hooks/class-validator-hook.ts
@@ -1,4 +1,8 @@
-import { FlagValue, Hook, HookContext } from '@openfeature/openfeature-js';
+import {
+  FlagEvaluationDetails,
+  Hook,
+  HookContext,
+} from '@openfeature/openfeature-js';
 import { validateSync } from 'class-validator';
 
 type Class = { new (data: any): any };
@@ -8,9 +12,10 @@ type Class = { new (data: any): any };
  */
 export class ClassValidatorHook implements Hook {
   constructor(private clazz: Class) {}
+  name = 'validator';
 
-  after(_: HookContext, flagValue: FlagValue) {
-    const instance = new this.clazz(flagValue);
+  after(_: HookContext, details: FlagEvaluationDetails<object>) {
+    const instance = new this.clazz(details.value);
     const result = validateSync(instance);
     if (result.length) {
       throw Error(`Invalid payload, result: ${result}`);

--- a/packages/openfeature-extra/src/lib/hooks/logging-hook.ts
+++ b/packages/openfeature-extra/src/lib/hooks/logging-hook.ts
@@ -1,25 +1,38 @@
-import { FlagValue, Hook, HookContext } from '@openfeature/openfeature-js';
+import {
+  FlagEvaluationDetails,
+  FlagValue,
+  Hook,
+  HookContext,
+} from '@openfeature/openfeature-js';
+import { EOL } from 'os';
 
 /**
  * A hook that simply logs at every life-cycle stage.
  */
 export class LoggingHook implements Hook {
+  name = 'logging';
   before(hookContext: HookContext) {
-    console.log(`Running 'before' logger hook for flag: ${hookContext.flagId}`);
+    console.log(
+      `Running 'before' logger hook for flag: ${hookContext.flagKey}`
+    );
     return hookContext.context;
   }
 
-  after(hookContext: HookContext, flagValue: FlagValue) {
-    console.log(`Running 'after' logger hook for flag: ${hookContext.flagId}`);
-    return flagValue;
+  after(hookContext: HookContext, details: FlagEvaluationDetails<FlagValue>) {
+    console.log(`Running 'after' logger hook for flag: ${hookContext.flagKey}`);
+    console.log(
+      `Evaluation details:${EOL}${JSON.stringify(details, undefined, 2)}`
+    );
   }
 
   finally(hookContext: HookContext) {
-    console.log(`Running 'finally' logger hook for flag: ${hookContext.flagId}`);
+    console.log(
+      `Running 'finally' logger hook for flag: ${hookContext.flagKey}`
+    );
   }
 
   error(hookContext: HookContext, err: Error) {
-    console.log(`Running 'error' logger hook for flag: ${hookContext.flagId}`);
+    console.log(`Running 'error' logger hook for flag: ${hookContext.flagKey}`);
     console.error(err);
   }
 }

--- a/packages/openfeature-extra/src/lib/hooks/open-telemetry-hook.ts
+++ b/packages/openfeature-extra/src/lib/hooks/open-telemetry-hook.ts
@@ -19,13 +19,14 @@ export class OpenTelemetryHook implements Hook {
   constructor(name: string) {
     this.tracer = trace.getTracer(name);
   }
+  name = 'open-telemetry';
 
   before(hookContext: HookContext) {
     const span = this.tracer.startSpan(
-      `feature flag - ${hookContext.flagType}`
+      `feature flag - ${hookContext.flagValueType}`
     );
     span.setAttributes({
-      [SpanProperties.FEATURE_FLAG_ID]: hookContext.flagId,
+      [SpanProperties.FEATURE_FLAG_ID]: hookContext.flagKey,
       [SpanProperties.FEATURE_FLAG_CLIENT_NAME]: hookContext.client.name,
       [SpanProperties.FEATURE_FLAG_CLIENT_VERSION]: hookContext.client.version,
       [SpanProperties.FEATURE_FLAG_SERVICE]: hookContext.provider.name,
@@ -41,7 +42,6 @@ export class OpenTelemetryHook implements Hook {
     this.spanMap
       .get(hookContext)
       ?.setAttribute(SpanProperties.FEATURE_FLAG_VALUE, primitiveFlagValue);
-    return flagValue;
   }
 
   finally(hookContext: HookContext) {

--- a/packages/openfeature-js/src/lib/api.ts
+++ b/packages/openfeature-js/src/lib/api.ts
@@ -9,7 +9,7 @@ import {
 } from './types';
 
 export class OpenFeatureAPI implements FlagEvaluationLifeCycle {
-  private provider?: FeatureProvider;
+  private provider?: FeatureProvider<unknown>;
   private _hooks: Hook[] = [];
 
   static getInstance(): OpenFeatureAPI {
@@ -31,11 +31,11 @@ export class OpenFeatureAPI implements FlagEvaluationLifeCycle {
     return new OpenFeatureClient(this, { name, version });
   }
 
-  registerProvider(provider: FeatureProvider): void {
+  registerProvider(provider: FeatureProvider<unknown>): void {
     this.provider = provider;
   }
 
-  getProvider(): FeatureProvider | undefined {
+  getProvider(): FeatureProvider<unknown> | undefined {
     return this.provider;
   }
 

--- a/packages/openfeature-js/src/lib/api.ts
+++ b/packages/openfeature-js/src/lib/api.ts
@@ -1,8 +1,14 @@
 import { OpenFeatureClient } from './client';
 import { getGlobal, registerGlobal } from './global';
-import { Client, FeatureProvider, FlagValue, HasHooks, Hook } from './types';
+import {
+  Client,
+  FeatureProvider,
+  FlagValue,
+  FlagEvaluationLifeCycle,
+  Hook,
+} from './types';
 
-export class OpenFeatureAPI implements HasHooks {
+export class OpenFeatureAPI implements FlagEvaluationLifeCycle {
   private provider?: FeatureProvider;
   private _hooks: Hook[] = [];
 

--- a/packages/openfeature-js/src/lib/client.ts
+++ b/packages/openfeature-js/src/lib/client.ts
@@ -184,7 +184,12 @@ export class OpenFeatureClient implements Client {
 
     try {
       this.beforeEvaluation(allHooks, hookContext);
-      const transformedContext = await provider.contextTransformer(context);
+
+      // if a transformer is defined, run it to prepare the context.
+      const transformedContext =
+        typeof provider.contextTransformer === 'function'
+          ? await provider.contextTransformer(context)
+          : context;
       switch (flagValueType) {
         case 'enabled': {
           evaluationDetailsPromise = provider.isEnabledEvaluation(
@@ -251,7 +256,6 @@ export class OpenFeatureClient implements Client {
       if (this.isError(err)) {
         this.errorEvaluation(allHooks, hookContext, err);
       }
-      // TODO: error condition - conditional typing.
       return {
         flagKey,
         executedHooks: hookContext.executedHooks,
@@ -334,7 +338,7 @@ export class OpenFeatureClient implements Client {
     return allHooks;
   }
 
-  private getProvider(): FeatureProvider {
+  private getProvider(): FeatureProvider<unknown> {
     return this.api.getProvider() ?? NOOP_FEATURE_PROVIDER;
   }
 

--- a/packages/openfeature-js/src/lib/errors.ts
+++ b/packages/openfeature-js/src/lib/errors.ts
@@ -1,35 +1,40 @@
-export enum ErrorCodes { 
-  GeneralError = 'GENERAL_ERROR',
-  FlagTypeError = 'FLAG_TYPE_ERROR',
-  FlagValueParseError = 'FLAG_VALUE_PARSE_ERROR'   
-};;
-
+import { ErrorCode } from './types';
 export abstract class OpenFeatureError extends Error {
-  abstract code: ErrorCodes;
+  abstract code: ErrorCode;
 }
 
 export class GeneralError extends OpenFeatureError {
-  code: ErrorCodes;
+  code: ErrorCode;
   constructor(message?: string) {
-      super(message);
-      Object.setPrototypeOf(this, FlagTypeError.prototype);
-      this.code = ErrorCodes.GeneralError;
-  }}
-
-export class FlagTypeError extends OpenFeatureError {
-  code: ErrorCodes;
-  constructor(message?: string) {
-      super(message);
-      Object.setPrototypeOf(this, FlagTypeError.prototype);
-      this.code = ErrorCodes.FlagTypeError;
+    super(message);
+    Object.setPrototypeOf(this, TypeMismatchError.prototype);
+    this.code = ErrorCode.GENERAL;
   }
 }
 
-export class FlagValueParseError extends OpenFeatureError {
-  code: ErrorCodes;
+export class TypeMismatchError extends OpenFeatureError {
+  code: ErrorCode;
   constructor(message?: string) {
-      super(message);
-      Object.setPrototypeOf(this, FlagTypeError.prototype);
-      this.code = ErrorCodes.FlagValueParseError;
+    super(message);
+    Object.setPrototypeOf(this, TypeMismatchError.prototype);
+    this.code = ErrorCode.TYPE_MISMATCH;
+  }
+}
+
+export class FlagNotFoundError extends OpenFeatureError {
+  code: ErrorCode;
+  constructor(message?: string) {
+    super(message);
+    Object.setPrototypeOf(this, FlagNotFoundError.prototype);
+    this.code = ErrorCode.FLAG_NOT_FOUND;
+  }
+}
+
+export class ParseError extends OpenFeatureError {
+  code: ErrorCode;
+  constructor(message?: string) {
+    super(message);
+    Object.setPrototypeOf(this, TypeMismatchError.prototype);
+    this.code = ErrorCode.PARSE_ERROR;
   }
 }

--- a/packages/openfeature-js/src/lib/noop-provider.ts
+++ b/packages/openfeature-js/src/lib/noop-provider.ts
@@ -1,7 +1,8 @@
 import { FeatureProvider, ProviderEvaluation, Reason } from './types';
-import { noopContextTransformer } from './utils';
 
 class NoopFeatureProvider implements FeatureProvider {
+  readonly contextTransformer = undefined;
+
   isEnabledEvaluation(
     _: string,
     defaultValue: boolean
@@ -12,8 +13,6 @@ class NoopFeatureProvider implements FeatureProvider {
     });
   }
   readonly name = 'No-op Provider';
-
-  contextTransformer = noopContextTransformer;
 
   isEnabled(_: string, defaultValue: boolean): Promise<boolean> {
     return Promise.resolve(defaultValue);

--- a/packages/openfeature-js/src/lib/noop-provider.ts
+++ b/packages/openfeature-js/src/lib/noop-provider.ts
@@ -1,26 +1,57 @@
-import { Context, FeatureProvider, FlagEvaluationOptions } from './types';
+import { FeatureProvider, ProviderEvaluation, Reason } from './types';
 import { noopContextTransformer } from './utils';
 
 class NoopFeatureProvider implements FeatureProvider {
-
+  isEnabledEvaluation(
+    _: string,
+    defaultValue: boolean
+  ): Promise<ProviderEvaluation<boolean>> {
+    return Promise.resolve({
+      value: defaultValue,
+      reason: Reason.DEFAULT,
+    });
+  }
   readonly name = 'No-op Provider';
 
   contextTransformer = noopContextTransformer;
 
-  isEnabled(id: string, defaultValue: boolean, context: Context | undefined, options?: FlagEvaluationOptions): Promise<boolean> {
+  isEnabled(_: string, defaultValue: boolean): Promise<boolean> {
     return Promise.resolve(defaultValue);
   }
-  getBooleanValue(flagId: string, defaultValue: boolean, context: Context | undefined, options?: FlagEvaluationOptions): Promise<boolean> {
-    return Promise.resolve(defaultValue);
+
+  getBooleanEvaluation(
+    _: string,
+    defaultValue: boolean
+  ): Promise<ProviderEvaluation<boolean>> {
+    return this.noOp(defaultValue);
   }
-  getStringValue(flagId: string, defaultValue: string, context: Context | undefined, options?: FlagEvaluationOptions): Promise<string> {
-    return Promise.resolve(defaultValue);
+
+  getStringEvaluation(
+    _: string,
+    defaultValue: string
+  ): Promise<ProviderEvaluation<string>> {
+    return this.noOp(defaultValue);
   }
-  getNumberValue(flagId: string, defaultValue: number, context: Context | undefined, options?: FlagEvaluationOptions): Promise<number> {
-    return Promise.resolve(defaultValue);
+
+  getNumberEvaluation(
+    _: string,
+    defaultValue: number
+  ): Promise<ProviderEvaluation<number>> {
+    return this.noOp(defaultValue);
   }
-  getObjectValue<T extends object>(flagId: string, defaultValue: T, context: Context | undefined, options?: FlagEvaluationOptions): Promise<T> {
-    return Promise.resolve(defaultValue);
+
+  getObjectEvaluation<T extends object>(
+    _: string,
+    defaultValue: T
+  ): Promise<ProviderEvaluation<T>> {
+    return this.noOp<T>(defaultValue);
+  }
+
+  private noOp<T>(defaultValue: T) {
+    return Promise.resolve({
+      value: defaultValue,
+      reason: Reason.DEFAULT,
+    });
   }
 }
 

--- a/packages/openfeature-js/src/lib/types.ts
+++ b/packages/openfeature-js/src/lib/types.ts
@@ -1,6 +1,14 @@
-export type Context = { userId?: string } & Record<string, string | number | boolean>;
+export type Context = { userId?: string } & Record<
+  string,
+  string | number | boolean
+>;
 
-export type FlagType = 'enabled' | 'boolean' | 'string' | 'number' | 'json';
+export type FlagValueType =
+  | 'enabled'
+  | 'boolean'
+  | 'string'
+  | 'number'
+  | 'json';
 
 export interface FlagEvaluationOptions {
   hooks?: Hook[];
@@ -16,7 +24,7 @@ export interface Features {
    * NOTE: In some providers this has distinct behavior from getBooleanValue
    */
   isEnabled(
-    flagId: string,
+    flagKey: string,
     defaultValue: boolean,
     context?: Context,
     options?: FlagEvaluationOptions
@@ -26,110 +34,151 @@ export interface Features {
    * Get a boolean flag value.
    */
   getBooleanValue(
-    flagId: string,
+    flagKey: string,
     defaultValue: boolean,
     context?: Context,
     options?: FlagEvaluationOptions
   ): Promise<boolean>;
 
   /**
+   * Get a boolean flag with additional details.
+   */
+  getBooleanDetails(
+    flagKey: string,
+    defaultValue: boolean,
+    context?: Context,
+    options?: FlagEvaluationOptions
+  ): Promise<FlagEvaluationDetails<boolean>>;
+
+  /**
    * Get a string flag value.
    */
   getStringValue(
-    flagId: string,
+    flagKey: string,
     defaultValue: string,
     context?: Context,
     options?: FlagEvaluationOptions
   ): Promise<string>;
 
   /**
+   * Get a string flag with additional details.
+   */
+  getStringDetails(
+    flagKey: string,
+    defaultValue: string,
+    context?: Context,
+    options?: FlagEvaluationOptions
+  ): Promise<FlagEvaluationDetails<string>>;
+
+  /**
    * Get a number flag value.
    */
   getNumberValue(
-    flagId: string,
+    flagKey: string,
     defaultValue: number,
     context?: Context,
     options?: FlagEvaluationOptions
   ): Promise<number>;
 
   /**
-   * Get a object (JSON) flag value.
+   * Get a number flag with additional details.
+   */
+  getNumberDetails(
+    flagKey: string,
+    defaultValue: number,
+    context?: Context,
+    options?: FlagEvaluationOptions
+  ): Promise<FlagEvaluationDetails<number>>;
+
+  /**
+   * Get an object (JSON) flag value.
    */
   getObjectValue<T extends object>(
-    flagId: string,
+    flagKey: string,
     defaultValue: T,
     context?: Context,
     options?: FlagEvaluationOptions
   ): Promise<T>;
+
+  /**
+   * Get an object (JSON) flag with additional details.
+   */
+  getObjectValue<T extends object>(
+    flagKey: string,
+    defaultValue: T,
+    context?: Context,
+    options?: FlagEvaluationOptions
+  ): Promise<FlagEvaluationDetails<T>>;
 }
 
-export type ContextTransformer<T = unknown> = (context: Context) => T
+export type ContextTransformer<T = unknown> = (context: Context) => T;
 
 /**
  * Interface that providers must implement to resolve flag values for their particular
  * backend or vendor.
- * 
+ *
  * Implementation for resolving all the required flag types must be defined.
- * 
+ *
  * Additionally, a ContextTransformer function that transforms the OpenFeature context to the requisite user/context/attribute representation (typeof T)
  * must also be implemented. This function will run immediately before the flag value resolver functions, appropriately transforming the context.
  */
 export interface FeatureProvider<T = unknown> {
   name: string;
   contextTransformer: ContextTransformer<Promise<T> | T>;
+
   /**
-   * Resolve a flag's activity. In some providers, this may be distinct from getting a boolean flag value.
+   * Resolve a flag's activity. In some providers, this may be distinct from
+   * getting a boolean flag value.
    */
-   isEnabled(
-    flagId: string,
+  isEnabledEvaluation(
+    flagKey: string,
     defaultValue: boolean,
-    transformedContext: T | undefined,
+    transformedContext: T,
     options?: FlagEvaluationOptions | undefined
-  ): Promise<boolean>;
+  ): Promise<ProviderEvaluation<boolean>>;
 
   /**
-   * Resolve a boolean flag value. In some providers, this may be distinct from getting a flag's activity.
+   * Resolve a boolean flag and it's evaluation details. In some providers, this may be distinct from getting a flag's activity.
    */
-  getBooleanValue(
-    flagId: string,
+  getBooleanEvaluation(
+    flagKey: string,
     defaultValue: boolean,
-    transformedContext: T | undefined,
+    transformedContext: T,
     options: FlagEvaluationOptions | undefined
-  ): Promise<boolean>;
+  ): Promise<ProviderEvaluation<boolean>>;
 
   /**
-   * Resolve a string flag value.
+   * Resolve a string flag and it's evaluation details.
    */
-  getStringValue(
-    flagId: string,
+  getStringEvaluation(
+    flagKey: string,
     defaultValue: string,
-    transformedContext: T | undefined,
+    transformedContext: T,
     options: FlagEvaluationOptions | undefined
-  ): Promise<string>;
+  ): Promise<ProviderEvaluation<string>>;
 
   /**
-   * Resolve a numeric flag value.
+   * Resolve a numeric flag and it's evaluation details.
    */
-  getNumberValue(
-    flagId: string,
+  getNumberEvaluation(
+    flagKey: string,
     defaultValue: number,
-    transformedContext: T | undefined,
+    transformedContext: T,
     options: FlagEvaluationOptions | undefined
-  ): Promise<number>;
+  ): Promise<ProviderEvaluation<number>>;
 
   /**
-   * Resolve an object flag value.
+   * Resolve and parse an object flag and it's evaluation details.
    */
-  getObjectValue<U extends object>(
-    flagId: string,
+  getObjectEvaluation<U extends object>(
+    flagKey: string,
     defaultValue: U,
-    transformedContext: T | undefined,
+    transformedContext: T,
     options: FlagEvaluationOptions | undefined
-  ): Promise<U>;
+  ): Promise<ProviderEvaluation<U>>;
 }
 
-// consider this name.
-export interface HasHooks {
+export interface FlagEvaluationLifeCycle {
   registerHooks(...hooks: Hook[]): void;
   get hooks(): Hook[];
 }
@@ -138,25 +187,63 @@ export interface ProviderOptions<T = unknown> {
   contextTransformer?: ContextTransformer<T>;
 }
 
-export interface Client extends HasHooks, Features {
+export type ProviderEvaluation<T> = {
+  value: T;
+  variant?: string;
+  reason: Reason;
+  errorCode?: ErrorCode;
+};
+
+export type FlagEvaluationDetails<T extends FlagValue> = {
+  flagKey: string;
+  executedHooks: ExecutedHooks;
+} & ProviderEvaluation<T>;
+
+export type ExecutedHooks = {
+  [P in keyof Omit<Hook<FlagValue>, 'name'>]-?: string[];
+};
+
+export enum Reason {
+  DISABLED = 'DISABLED',
+  SPLIT = 'SPLIT',
+  TARGETING_MATCH = 'TARGETING_MATCH',
+  DEFAULT = 'DEFAULT',
+  UNKNOWN = 'UNKNOWN',
+  ERROR = 'ERROR',
+}
+
+export enum ErrorCode {
+  PROVIDER_NOT_READY = 'PROVIDER_NOT_READY',
+  FLAG_NOT_FOUND = 'FLAG_NOT_FOUND',
+  PARSE_ERROR = 'PARSE_ERROR',
+  TYPE_MISMATCH = 'TYPE_MISMATCH',
+  GENERAL = 'GENERAL',
+}
+
+export interface Client extends FlagEvaluationLifeCycle, Features {
   readonly name?: string;
   readonly version?: string;
 }
 
 export type HookContext = {
-  flagId: string;
-  flagType: FlagType;
-  provider: FeatureProvider;
+  flagKey: string;
+  flagValueType: FlagValueType;
   client: Client;
   context: Context;
+  provider: FeatureProvider;
   defaultValue: FlagValue;
+  executedHooks: ExecutedHooks;
 };
 
 export type FlagValue = boolean | string | number | object;
 
-export interface Hook<T = FlagValue> {
-  before?(hookContext: HookContext): Context;
-  after?(hookContext: HookContext, flagValue: T): T;
-  error?(hookContext: HookContext, error: Error): void;
-  finally?(hookContext: HookContext): void;
+export interface Hook<T extends FlagValue = FlagValue> {
+  name: string;
+  before?(hookContext: Readonly<HookContext>): Context;
+  after?(
+    hookContext: Readonly<HookContext>,
+    evaluationDetails: FlagEvaluationDetails<T>
+  ): T | void;
+  error?(hookContext: Readonly<HookContext>, error: Error): void;
+  finally?(hookContext: Readonly<HookContext>): void;
 }

--- a/packages/openfeature-js/src/lib/types.ts
+++ b/packages/openfeature-js/src/lib/types.ts
@@ -31,6 +31,18 @@ export interface Features {
   ): Promise<boolean>;
 
   /**
+   * Get a boolean flag with additional details.
+   *
+   * NOTE: In some providers this has distinct behavior from getBooleanDetails
+   */
+  isEnabledDetails(
+    flagKey: string,
+    defaultValue: boolean,
+    context?: Context,
+    options?: FlagEvaluationOptions
+  ): Promise<FlagEvaluationDetails<boolean>>;
+
+  /**
    * Get a boolean flag value.
    */
   getBooleanValue(

--- a/packages/openfeature-js/src/lib/types.ts
+++ b/packages/openfeature-js/src/lib/types.ts
@@ -210,7 +210,7 @@ export interface ProviderOptions<T = unknown> {
 export type ProviderEvaluation<T> = {
   value: T;
   variant?: string;
-  reason: Reason;
+  reason: Reason | string;
   errorCode?: ErrorCode;
 };
 
@@ -223,6 +223,11 @@ export type ExecutedHooks = {
   [P in keyof Omit<Hook<FlagValue>, 'name'>]-?: string[];
 };
 
+/**
+ * TODO: Do we want OpenFeature to rigorously define a set of reasons and force providers to map their own reasons?
+ * Do we anticipate Application Authors or Integrators writing logic based on these values, or are they
+ * only important for diagnostics/telemetry/troubleshooting?
+ */
 export enum Reason {
   DISABLED = 'DISABLED',
   SPLIT = 'SPLIT',

--- a/packages/openfeature-js/src/lib/types.ts
+++ b/packages/openfeature-js/src/lib/types.ts
@@ -251,7 +251,7 @@ export type FlagValue = boolean | string | number | object;
 
 export interface Hook<T extends FlagValue = FlagValue> {
   name: string;
-  before?(hookContext: Readonly<HookContext>): Context;
+  before?(hookContext: Readonly<HookContext>): Context | void;
   after?(
     hookContext: Readonly<HookContext>,
     evaluationDetails: FlagEvaluationDetails<T>

--- a/packages/openfeature-js/src/lib/utils.ts
+++ b/packages/openfeature-js/src/lib/utils.ts
@@ -1,42 +1,53 @@
-import { FlagTypeError, FlagValueParseError } from './errors';
+import { TypeMismatchError, ParseError } from './errors';
 import { Context, ContextTransformer } from './types';
 
-export const parseValidNumber = (stringValue: string) => {
+export const parseValidNumber = (stringValue: string | undefined) => {
+  if (stringValue === undefined) {
+    throw new ParseError(`Invalid 'undefined' value.`);
+  }
   const result = Number.parseFloat(stringValue);
   if (Number.isNaN(result)) {
-    throw new FlagTypeError(`Invalid numeric value ${stringValue}`);
+    throw new TypeMismatchError(`Invalid numeric value ${stringValue}`);
   }
   return result;
 };
 
-export const parseValidBoolean = (stringValue: string) => {
+export const parseValidBoolean = (stringValue: string | undefined) => {
   const asUnknown = stringValue as unknown;
 
   switch (asUnknown) {
-    case 'true': 
+    case 'true':
       return true;
     case 'false':
       return false;
-    case true: 
+    case true:
       return true;
     case false:
       return false;
     default:
-      throw new FlagTypeError(`Invalid boolean value for ${asUnknown}`)
+      throw new TypeMismatchError(`Invalid boolean value for ${asUnknown}`);
   }
 };
 
-export const parseValidJsonObject = <T extends object>(stringValue: string): T => {
+export const parseValidJsonObject = <T extends object>(
+  stringValue: string | undefined
+): T => {
+  if (stringValue === undefined) {
+    throw new ParseError(`Invalid 'undefined' JSON value.`);
+  }
   // we may want to allow the parsing to be customized.
   try {
     const value = JSON.parse(stringValue);
     if (typeof value === 'object') {
-      throw new FlagTypeError(`Flag value ${stringValue} had unexpected type ${typeof value}, expected "object"`);
+      throw new TypeMismatchError(
+        `Flag value ${stringValue} had unexpected type ${typeof value}, expected "object"`
+      );
     }
     return value;
   } catch (err) {
-    throw new FlagValueParseError(`Error parsing ${stringValue} as JSON`);
+    throw new ParseError(`Error parsing ${stringValue} as JSON`);
   }
-}
+};
 
-export const noopContextTransformer: ContextTransformer = (context: Context) => context;
+export const noopContextTransformer: ContextTransformer = (context: Context) =>
+  context;

--- a/packages/openfeature-js/src/lib/utils.ts
+++ b/packages/openfeature-js/src/lib/utils.ts
@@ -37,13 +37,13 @@ export const parseValidJsonObject = <T extends object>(
   // we may want to allow the parsing to be customized.
   try {
     const value = JSON.parse(stringValue);
-    if (typeof value === 'object') {
+    if (typeof value !== 'object') {
       throw new TypeMismatchError(
         `Flag value ${stringValue} had unexpected type ${typeof value}, expected "object"`
       );
     }
     return value;
   } catch (err) {
-    throw new ParseError(`Error parsing ${stringValue} as JSON`);
+    throw new ParseError(`Error parsing ${stringValue} as JSON, ${err}`);
   }
 };

--- a/packages/openfeature-js/src/lib/utils.ts
+++ b/packages/openfeature-js/src/lib/utils.ts
@@ -1,5 +1,4 @@
-import { TypeMismatchError, ParseError } from './errors';
-import { Context, ContextTransformer } from './types';
+import { ParseError, TypeMismatchError } from './errors';
 
 export const parseValidNumber = (stringValue: string | undefined) => {
   if (stringValue === undefined) {
@@ -48,6 +47,3 @@ export const parseValidJsonObject = <T extends object>(
     throw new ParseError(`Error parsing ${stringValue} as JSON`);
   }
 };
-
-export const noopContextTransformer: ContextTransformer = (context: Context) =>
-  context;

--- a/tools/generators/provider-generator/files/provider/src/lib/__fileName__.ts__tmpl__
+++ b/tools/generators/provider-generator/files/provider/src/lib/__fileName__.ts__tmpl__
@@ -1,29 +1,58 @@
 import {
-  Context,
+  ContextTransformer,
   FeatureProvider,
-  FlagEvaluationOptions
+  FlagEvaluationOptions,
+  noopContextTransformer,
+  ProviderEvaluation,
 } from '@openfeature/openfeature-js';
 
 export class <%= libClassName %> implements FeatureProvider {
+  
   name = '<%= name %>';
-
-  isEnabled(flagKey: string, defaultValue: boolean, context: Context, options?: FlagEvaluationOptions): Promise<boolean> {
+  contextTransformer: ContextTransformer<unknown> = noopContextTransformer;
+  
+  isEnabledEvaluation(
+    flagKey: string,
+    defaultValue: boolean,
+    transformedContext: unknown,
+    options?: FlagEvaluationOptions
+  ): Promise<ProviderEvaluation<boolean>> {
     throw new Error('Method not implemented.');
   }
 
-  getBooleanValue(flagKey: string, defaultValue: boolean, context: Context, options?: FlagEvaluationOptions): Promise<boolean> {
+  getBooleanEvaluation(
+    flagKey: string,
+    defaultValue: boolean,
+    transformedContext: unknown,
+    options: FlagEvaluationOptions | undefined
+  ): Promise<ProviderEvaluation<boolean>> {
     throw new Error('Method not implemented.');
   }
 
-  getStringValue(flagKey: string, defaultValue: string, context: Context, options?: FlagEvaluationOptions): Promise<string> {
+  getStringEvaluation(
+    flagKey: string,
+    defaultValue: string,
+    transformedContext: unknown,
+    options: FlagEvaluationOptions | undefined
+  ): Promise<ProviderEvaluation<string>> {
     throw new Error('Method not implemented.');
   }
 
-  getNumberValue(flagKey: string, defaultValue: number, context: Context, options?: FlagEvaluationOptions): Promise<number> {
+  getNumberEvaluation(
+    flagKey: string,
+    defaultValue: number,
+    transformedContext: unknown,
+    options: FlagEvaluationOptions | undefined
+  ): Promise<ProviderEvaluation<number>> {
     throw new Error('Method not implemented.');
   }
 
-  getObjectValue<T extends object>(flagKey: string, defaultValue: T, context: Context, options?: FlagEvaluationOptions): Promise<T> {
+  getObjectEvaluation<U extends object>(
+    flagKey: string,
+    defaultValue: U,
+    transformedContext: unknown,
+    options: FlagEvaluationOptions | undefined
+  ): Promise<ProviderEvaluation<U>> {
     throw new Error('Method not implemented.');
   }
 }

--- a/tools/generators/provider-generator/files/provider/src/lib/__fileName__.ts__tmpl__
+++ b/tools/generators/provider-generator/files/provider/src/lib/__fileName__.ts__tmpl__
@@ -7,23 +7,23 @@ import {
 export class <%= libClassName %> implements FeatureProvider {
   name = '<%= name %>';
 
-  isEnabled(flagId: string, defaultValue: boolean, context: Context, options?: FlagEvaluationOptions): Promise<boolean> {
+  isEnabled(flagKey: string, defaultValue: boolean, context: Context, options?: FlagEvaluationOptions): Promise<boolean> {
     throw new Error('Method not implemented.');
   }
 
-  getBooleanValue(flagId: string, defaultValue: boolean, context: Context, options?: FlagEvaluationOptions): Promise<boolean> {
+  getBooleanValue(flagKey: string, defaultValue: boolean, context: Context, options?: FlagEvaluationOptions): Promise<boolean> {
     throw new Error('Method not implemented.');
   }
 
-  getStringValue(flagId: string, defaultValue: string, context: Context, options?: FlagEvaluationOptions): Promise<string> {
+  getStringValue(flagKey: string, defaultValue: string, context: Context, options?: FlagEvaluationOptions): Promise<string> {
     throw new Error('Method not implemented.');
   }
 
-  getNumberValue(flagId: string, defaultValue: number, context: Context, options?: FlagEvaluationOptions): Promise<number> {
+  getNumberValue(flagKey: string, defaultValue: number, context: Context, options?: FlagEvaluationOptions): Promise<number> {
     throw new Error('Method not implemented.');
   }
 
-  getObjectValue<T extends object>(flagId: string, defaultValue: T, context: Context, options?: FlagEvaluationOptions): Promise<T> {
+  getObjectValue<T extends object>(flagKey: string, defaultValue: T, context: Context, options?: FlagEvaluationOptions): Promise<T> {
     throw new Error('Method not implemented.');
   }
 }


### PR DESCRIPTION
This is a first pass at an API for getting additional flag evaluation details (see [here](https://github.com/open-feature/sdk-research/compare/detail-methods?expand=1#diff-b55a5ac5cdc4b41e408c486eac934b2d73e9b3cf4ee4d984bc51c20c98e20f6fR202-R212) for the structure of the details and [here](https://github.com/open-feature/sdk-research/compare/detail-methods?expand=1#diff-b55a5ac5cdc4b41e408c486eac934b2d73e9b3cf4ee4d984bc51c20c98e20f6fR55-R64) for an example of one of the new methods).

Some, but not all providers are currently able to provide this additional metadata, so the presence of this data is "best effort". The precise semantics of the various properties are certainly up for discussion (the `errorCodes` and `reasons` for example). The idea is to support mapping custom provider codes and errors to well-defined enumerations in OpenFeature (see the the mapping in the [LaunchDarkly demo provider](https://github.com/open-feature/sdk-research/compare/detail-methods?expand=1#diff-99ca5eae1a8094549f1799c85824c112816da5da781a7b301ea4c4d6e15713baR169-R197) for example).

Many of the field names in the `FlagEvaluationDetails` schema are also used in the proposed OTel semantics.

I've also update the README in the root, which had become somewhat out of date.
